### PR TITLE
Update package.json to support React >= 15.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/cezary/react-favicon",
   "peerDependencies": {
-    "react": ">=0.12.0 < 15.0.x"
+    "react": "0.12.x || 0.13.x || 0.14.x || ^15.0.0-0"
   },
   "devDependencies": {
     "babel": "^5.1.10"


### PR DESCRIPTION
I'm not sure if this is the syntax you're looking for (as I've seen others use ^0.14.0 or not just >= 0.12.0 or something else)  but right now using the packager causes npm install to error out.